### PR TITLE
feat: 前端功能优化与代码重构

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue';
 import Navigation from './components/NavbarComponent.vue';
+import Toast from './components/ToastComponent.vue';
 import { RouterView } from 'vue-router';
 
 const isMobile = ref(false);
@@ -19,9 +20,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-	<Navigation :isMobile="isMobile"/>
+	<Toast />
+	<Navigation :isMobile="isMobile" />
 	<main class="container">
-		<RouterView/>
+		<RouterView />
 	</main>
 </template>
 

--- a/src/components/BindMainAccountComponent.vue
+++ b/src/components/BindMainAccountComponent.vue
@@ -3,6 +3,7 @@ import { getPrefix } from '@/utils/prefix';
 import { logout, requestBindMainAccount, type UserData } from '@/utils/user';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
+import { showToast } from '@/components/ToastComponent.vue';
 
 const props = defineProps(['user'])
 const router = useRouter();
@@ -10,34 +11,32 @@ const user = ref<UserData>(props.user);
 const mainAccountID = ref("");
 const bindActivateCode = ref("");
 
-
 async function bindMainAccount() {
-	const code = await requestBindMainAccount(mainAccountID.value);
-	if (code === undefined) {
-		alert("激活码获取失败，请稍后重试。");
-		mainAccountID.value = "";
-	} else {
-		bindActivateCode.value = `${ await getPrefix() }account bind ${ code }`;
-	}
+    const code = await requestBindMainAccount(mainAccountID.value);
+    if (code === undefined) {
+        showToast("激活码获取失败，请稍后重试", "error");
+        mainAccountID.value = "";
+    } else {
+        bindActivateCode.value = `${await getPrefix()}account bind ${code}`;
+    }
 }
 
 function logoutEvent() {
-	logout();
-	router.push('/login');
+    logout();
+    router.push('/login');
 }
-
 </script>
 
 <template>
-	<h2>绑定母帐号</h2>
-	<div class="form" v-if="!bindActivateCode">
-		<mdui-text-field label="帐号ID" :value="mainAccountID" @input="mainAccountID = $event.target.value" clearable></mdui-text-field>
-		<p>绑定后此账号的所有事件都会被认为是母账号发出的，暂不支持解绑。</p>
-		<mdui-button @click="bindMainAccount()">绑定</mdui-button>
-	</div>
-	<div v-else>
-		<p>请使用 {{ mainAccountID }} 输入以下指令进行激活: </p>
-		<mdui-text-field :value="bindActivateCode" readonly></mdui-text-field>
-		<a :href="void logoutEvent()">我已完成绑定，退出登录</a>
-	</div>
+    <h2>绑定母帐号</h2>
+    <div class="form" v-if="!bindActivateCode">
+        <mdui-text-field label="帐号ID" :value="mainAccountID" @input="mainAccountID = ($event.target as HTMLInputElement).value" clearable></mdui-text-field>
+        <p>绑定后此账号的所有事件都会被认为是母账号发出的，暂不支持解绑。</p>
+        <mdui-button @click="bindMainAccount()">绑定</mdui-button>
+    </div>
+    <div v-else>
+        <p>请使用 {{ mainAccountID }} 输入以下指令进行激活:</p>
+        <mdui-text-field :value="bindActivateCode" readonly></mdui-text-field>
+        <a :href="void logoutEvent()">我已完成绑定，退出登录</a>
+    </div>
 </template>

--- a/src/components/ChangeNickName.vue
+++ b/src/components/ChangeNickName.vue
@@ -1,33 +1,30 @@
 <script setup lang="ts">
 import { postChangeNickname, type UserData } from '@/utils/user';
 import { ref } from 'vue';
+import { showToast } from '@/components/ToastComponent.vue';
 
 const props = defineProps(['user'])
 const user = ref<UserData>(props.user);
 const newNickname = ref(user.value.nickname);
 
 async function changeNickname() {
-	const result = await postChangeNickname(newNickname.value);
-	if (result.success) {
-		location.reload();
-	} else {
-		alert(result.message);
-	}
+    const result = await postChangeNickname(newNickname.value);
+    if (result.success) {
+        showToast("昵称修改成功", "success");
+        setTimeout(() => location.reload(), 800);
+    } else {
+        showToast(result.message || "修改失败", "error");
+    }
 }
-
-
 </script>
 
 <template>
-	<div v-if="user">
-		<h2>修改昵称</h2>
-		
-		<mdui-text-field label="新的昵称" :value="newNickname" @input="newNickname = $event.target.value" clearable></mdui-text-field>
-		<p>更改后昵称将不再随 IM 中的昵称更改，解除锁定请留空。</p>
-		<mdui-button @click="changeNickname()">修改</mdui-button>
-		
-		
-	</div>
-	<h1 v-else>加载中</h1>
-</template>
+    <div v-if="user">
+        <h2>修改昵称</h2>
 
+        <mdui-text-field label="新的昵称" :value="newNickname" @input="newNickname = ($event.target as HTMLInputElement).value" clearable></mdui-text-field>
+        <p>更改后昵称将不再随 IM 中的昵称更改，解除锁定请留空。</p>
+        <mdui-button @click="changeNickname()">修改</mdui-button>
+    </div>
+    <h1 v-else>加载中</h1>
+</template>

--- a/src/components/NavbarComponent.vue
+++ b/src/components/NavbarComponent.vue
@@ -1,61 +1,65 @@
 <script setup lang="ts">
 import { setTheme } from 'mdui/functions/setTheme';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type { Theme } from "mdui/internal/theme";
 import { getCurrentUser, isLoggedIn, type UserData } from "@/utils/user";
 import { useDark } from "@vueuse/core";
 
 const user = ref<UserData>();
-
-onMounted(async () => {
-	user.value = await isLoggedIn() ? await getCurrentUser() : undefined;
-});
-
 const router = useRouter();
 const route = useRoute();
 const darkMode = useDark();
-const activatedItem = ref("home");
 const props = defineProps({ isMobile: Boolean });
 
+// 根据当前路由计算 active 值
+const activeValue = computed(() => {
+    const name = String(route.name || 'home');
+    return name === '' ? 'home' : name;
+});
+
+onMounted(async () => {
+    user.value = await isLoggedIn() ? await getCurrentUser() : undefined;
+});
+
 function changeTheme(dark: boolean) {
-	darkMode.value = dark;
-	let theme: Theme = dark ? "dark" : "light";
-	setTheme(theme);
+    darkMode.value = dark;
+    let theme: Theme = dark ? "dark" : "light";
+    setTheme(theme);
 }
 
 onMounted(() => {
-	changeTheme(darkMode.value);
+    changeTheme(darkMode.value);
 });
 
-async function changePage(page: string) {
-	activatedItem.value = page;
-	await router.push(`/${ page }`);
+function navigateTo(page: string) {
+    const path = page === 'home' ? '/' : `/${page}`;
+    router.push(path);
 }
 
 </script>
 
 <template>
-	<mdui-navigation-rail v-if="!props.isMobile" :value="route.name" divider>
-		<mdui-button-icon slot="top">
-			<mdui-avatar src="https://moonlark-wiki.itcdt.top//images/f/f8/Moonlark.png"></mdui-avatar>
-		</mdui-button-icon>
-		<mdui-fab size="small" icon="people--outlined" value="user" @click="changePage('user')" slot="top"></mdui-fab>
-		<mdui-navigation-rail-item icon="home--outlined" value="home" @click="changePage('')">主页
-		</mdui-navigation-rail-item>
-		<mdui-navigation-rail-item icon="list--outlined" value="rankings" @click="changePage('rankings')">排行
-		</mdui-navigation-rail-item>
-		<mdui-button-icon v-if="user" icon="settings--outlined" @click="changePage('settings')" slot="bottom"></mdui-button-icon>
-		<mdui-button-icon icon="source--outlined" slot="bottom" href="https://github.com/Moonlark-Dev/Moonlark" target="_blank"></mdui-button-icon>
-		<mdui-button-icon @click="changeTheme(false)" v-if="darkMode" icon="dark_mode--outlined" slot="bottom"></mdui-button-icon>
-		<mdui-button-icon @click="changeTheme(true)" v-else icon="light_mode--outlined" slot="bottom"></mdui-button-icon>
-	</mdui-navigation-rail>
-	<mdui-navigation-bar v-else :value="activatedItem" scroll-behavior="hide">
-		<mdui-navigation-bar-item icon="home--outlined" value="home" @click="changePage('')">主页
-		</mdui-navigation-bar-item>
-		<mdui-navigation-bar-item icon="people--outlined" value="user" @click="changePage('user')">用户
-		</mdui-navigation-bar-item>
-		<mdui-navigation-bar-item icon="list--outlined" value="rankings" @click="changePage('rankings')">排行
-		</mdui-navigation-bar-item>
-	</mdui-navigation-bar>
+    <mdui-navigation-rail v-if="!props.isMobile" :value="activeValue" divider>
+        <mdui-button-icon slot="top">
+            <mdui-avatar src="https://moonlark-wiki.itcdt.top//images/f/f8/Moonlark.png"></mdui-avatar>
+        </mdui-button-icon>
+        <mdui-fab size="small" icon="people--outlined" value="user" @click="navigateTo('user')" slot="top"></mdui-fab>
+        <mdui-navigation-rail-item icon="home--outlined" value="home" @click="navigateTo('home')">主页
+        </mdui-navigation-rail-item>
+        <mdui-navigation-rail-item icon="list--outlined" value="rankings" @click="navigateTo('rankings')">排行
+        </mdui-navigation-rail-item>
+        <mdui-button-icon v-if="user" icon="settings--outlined" @click="navigateTo('settings')" slot="bottom"></mdui-button-icon>
+        <mdui-button-icon icon="source--outlined" slot="bottom" href="https://github.com/Moonlark-Dev/Moonlark" target="_blank"></mdui-button-icon>
+        <mdui-button-icon @click="changeTheme(false)" v-if="darkMode" icon="dark_mode--outlined" slot="bottom"></mdui-button-icon>
+        <mdui-button-icon @click="changeTheme(true)" v-else icon="light_mode--outlined" slot="bottom"></mdui-button-icon>
+    </mdui-navigation-rail>
+    <mdui-navigation-bar v-else :value="activeValue" scroll-behavior="hide">
+        <mdui-navigation-bar-item icon="home--outlined" value="home" @click="navigateTo('home')">主页
+        </mdui-navigation-bar-item>
+        <mdui-navigation-bar-item icon="people--outlined" value="user" @click="navigateTo('user')">用户
+        </mdui-navigation-bar-item>
+        <mdui-navigation-bar-item icon="list--outlined" value="rankings" @click="navigateTo('rankings')">排行
+        </mdui-navigation-bar-item>
+    </mdui-navigation-bar>
 </template>

--- a/src/components/ToastComponent.vue
+++ b/src/components/ToastComponent.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+interface ToastMessage {
+    id: number;
+    text: string;
+    type: "info" | "success" | "error";
+}
+
+const messages = ref<ToastMessage[]>([]);
+let nextId = 0;
+
+export function showToast(text: string, type: "info" | "success" | "error" = "info") {
+    const id = nextId++;
+    messages.value.push({ id, text, type });
+    setTimeout(() => {
+        messages.value = messages.value.filter((m) => m.id !== id);
+    }, 3000);
+}
+</script>
+
+<template>
+    <div class="toast-container">
+        <mdui-snackbar
+            v-for="msg of messages"
+            :key="msg.id"
+            :class="'toast-' + msg.type"
+            closeable
+        >
+            {{ msg.text }}
+        </mdui-snackbar>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.toast-container {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-width: 360px;
+    pointer-events: none;
+
+    > * {
+        pointer-events: auto;
+    }
+}
+
+.toast-success {
+    --mdui-color-primary: #4caf50;
+}
+
+.toast-error {
+    --mdui-color-primary: #f44336;
+}
+</style>

--- a/src/pages/HomeView.vue
+++ b/src/pages/HomeView.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import { getCurrentUser } from '@/utils/user';
+import { getCurrentUser, isLoggedIn } from '@/utils/user';
 
 const nickname = ref("用户");
 
 onMounted(async () => {
-	let user = await getCurrentUser();
-	if (user) nickname.value = user.nickname ||  "未登录用户";
+    if (!await isLoggedIn()) {
+        nickname.value = "未登录用户";
+        return;
+    }
+    try {
+        let user = await getCurrentUser();
+        if (user) nickname.value = user.nickname || "未登录用户";
+    } catch {
+        nickname.value = "未登录用户";
+    }
 });
-
 </script>
 
 <template>

--- a/src/pages/LoginView.vue
+++ b/src/pages/LoginView.vue
@@ -11,53 +11,111 @@ const userID = ref<string | null>(null);
 const verifyInterval = ref(0);
 const router = useRouter();
 let intervalId: number[] = [];
+const loginError = ref("");
+
+function clearIntervals() {
+    intervalId.forEach(id => clearInterval(id));
+    intervalId = [];
+}
 
 async function checkLogin() {
-	if (await isLoggedIn()) router.back();
+    if (await isLoggedIn()) {
+        clearIntervals();
+        router.back();
+    }
 }
 
 function changeTimer() {
-	verifyInterval.value -= 1;
+    verifyInterval.value -= 1;
+    if (verifyInterval.value <= 0) {
+        clearIntervals();
+        step.value = 2; // timeout
+    }
 }
 
 async function getActivateCode() {
-	let data = await login(userID.value!!);
-	activateCode.value = `${ await getPrefix() }account verify ${ data.activate_code }`;
-	step.value = 1;
-	verifyInterval.value = data.effective_time;
-	intervalId.push(setInterval(checkLogin, 1000));
-	intervalId.push(setInterval(changeTimer, 1000));
+    if (!userID.value?.trim()) {
+        loginError.value = "请输入用户ID";
+        return;
+    }
+    loginError.value = "";
+    try {
+        const data = await login(userID.value);
+        activateCode.value = `${await getPrefix()}account verify ${data.activate_code}`;
+        step.value = 1;
+        verifyInterval.value = data.effective_time;
+        intervalId.push(setInterval(checkLogin, 1000));
+        intervalId.push(setInterval(changeTimer, 1000));
+    } catch {
+        loginError.value = "登录失败，请检查用户ID是否正确";
+    }
 }
 
-onMounted(
-	async () => {
-		if (await isLoggedIn()) await router.push("/");
-	}
-);
+function goBack() {
+    clearIntervals();
+    step.value = 0;
+}
+
+function retryLogin() {
+    step.value = 0;
+}
+
+onMounted(async () => {
+    if (await isLoggedIn()) await router.push("/");
+});
 
 onUnmounted(() => {
-	intervalId.forEach(value => {
-		clearInterval(value);
-	});
+    clearIntervals();
 });
 </script>
 
 <template>
-	<h1>登录</h1>
-	<div v-if="step === 0" :class="{ form: !props.isMobile }">
-		<mdui-text-field label="用户ID" :value="userID" @input="userID = $event.target.value" clearable></mdui-text-field>
-		<p></p>
-		<mdui-button @click="getActivateCode()">确认</mdui-button>
-	</div>
-	<div v-if="step === 1" :class="{ form: !props.isMobile }">
-		<p>请在 Moonlark 中输入以下指令进行激活: </p>
-		<mdui-text-field :value="activateCode" readonly></mdui-text-field>
-		<small>请在 <strong>{{ verifyInterval }}s</strong> 内完成登录验证</small>
-	</div>
+    <h1>登录</h1>
+
+    <!-- Step 0: Enter user ID -->
+    <div v-if="step === 0" :class="{ form: !props.isMobile }">
+        <mdui-text-field label="用户ID" :value="userID" @input="userID = ($event.target as HTMLInputElement).value"
+            clearable :error="!!loginError" :helper-text="loginError"></mdui-text-field>
+        <p></p>
+        <mdui-button @click="getActivateCode()">确认</mdui-button>
+        &nbsp;
+        <mdui-button @click="router.push('/')" variant="text">返回首页</mdui-button>
+    </div>
+
+    <!-- Step 1: Verify -->
+    <div v-else-if="step === 1" :class="{ form: !props.isMobile }">
+        <p>请在 Moonlark 中输入以下指令进行激活:</p>
+        <mdui-text-field :value="activateCode" readonly></mdui-text-field>
+        <small>请在 <strong>{{ verifyInterval }}s</strong> 内完成登录验证</small>
+        <p></p>
+        <mdui-button @click="goBack" variant="text">重新输入</mdui-button>
+    </div>
+
+    <!-- Step 2: Timeout -->
+    <div v-else-if="step === 2" :class="{ form: !props.isMobile }" class="state-box">
+        <mdui-icon name="timer_off" style="font-size: 48px; color: #f44336;"></mdui-icon>
+        <p>验证超时，请重新登录</p>
+        <mdui-button @click="retryLogin">重新登录</mdui-button>
+    </div>
 </template>
 
 <style scoped lang="scss">
 .form {
-	width: 50%;
+    width: 50%;
+}
+
+.state-box {
+    text-align: center;
+    padding: 40px 20px;
+
+    p {
+        margin: 16px 0;
+    }
+}
+
+@media (max-width: 768px) {
+    .form {
+        width: 100%;
+    }
 }
 </style>

--- a/src/pages/RankingsView.vue
+++ b/src/pages/RankingsView.vue
@@ -1,46 +1,115 @@
 <script setup lang="ts">
 import { getRankingByURI, getRankings, type Ranking, type Rankings } from "@/utils/ranking";
+import { getSessionIDOrNull } from "@/utils/api";
 import { onMounted, ref } from "vue";
+import { showToast } from "@/components/ToastComponent.vue";
 
 const rankingData = ref<Record<string, Ranking>>({});
+const loading = ref(true);
+const error = ref(false);
 
-async function * fetchRankingData() {
-	const rankings: Rankings = await getRankings();
-	const race = Object.values(rankings).map(async item => [ item.name, await getRankingByURI(item.uri) ] as [ string, Ranking ]);
-	for (const item of await Promise.allSettled(race)) {
-		if (item.status == "fulfilled") yield item.value;
-	}
+async function* fetchRankingData() {
+    try {
+        const rankings: Rankings = await getRankings();
+        const entries = Object.entries(rankings);
+        if (entries.length === 0) return;
+        const race = entries.map(async ([, info]) => [info.name, await getRankingByURI(info.uri)] as [string, Ranking]);
+        for (const item of await Promise.allSettled(race)) {
+            if (item.status === "fulfilled") yield item.value;
+            else {
+                showToast("部分排行加载失败", "error");
+            }
+        }
+    } catch {
+        error.value = true;
+        showToast("排行数据加载失败", "error");
+    }
 }
 
-onMounted(
-	async () => {
-		const entries: Record<string, Ranking> = {};
-		for await (const item of fetchRankingData()) entries[item[0]] = item[1];
-		rankingData.value = entries;
-	}
-);
+onMounted(async () => {
+    const entries: Record<string, Ranking> = {};
+    for await (const item of fetchRankingData()) {
+        if (item) entries[item[0]] = item[1];
+    }
+    rankingData.value = entries;
+    loading.value = false;
+});
 
 function showDate(time: number) {
-	const date = new Date(time);
-	return ("0" + date.getHours()).slice(-2) + ':' + ("0" + date.getMinutes()).slice(-2) + ":" + ("0" + date.getSeconds()).slice(-2);
+    const date = new Date(time * 1000);
+    return ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2) + ":" + ("0" + date.getSeconds()).slice(-2);
 }
 
+const loggedIn = getSessionIDOrNull() !== null;
 </script>
 
 <template>
-	<h1>排行</h1>
-	<mdui-list>
-		<mdui-collapse accordion>
-			<mdui-collapse-item v-for="[rankingName, ranking] of Object.entries(rankingData)" v-bind:key="ranking">
-				<mdui-list-item slot="header" icon="leaderboard">
-					<h3>{{ rankingName }} ({{ ranking.total }}) - {{ showDate(ranking.time) }}</h3>
-				</mdui-list-item>
-				<mdui-list-item v-for="user of ranking.users"
-								v-bind:key="user">
-					{{ user.index }}. {{ user.nickname }} ({{ user.info ?? user.user_id }}) - {{ user.data }}
-				</mdui-list-item>
-				<mdui-divider inset></mdui-divider>
-			</mdui-collapse-item>
-		</mdui-collapse>
-	</mdui-list>
+    <h1>排行</h1>
+
+    <!-- Loading -->
+    <div v-if="loading" class="state-box">
+        <mdui-linear-progress indeterminate></mdui-linear-progress>
+        <p>正在加载排行数据...</p>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="state-box">
+        <mdui-icon name="error_outline" style="font-size: 48px; color: #f44336;"></mdui-icon>
+        <p>排行数据加载失败，请稍后重试</p>
+        <mdui-button @click="() => { loading = true; error = false; onMounted(() => {}); location.reload(); }">重新加载</mdui-button>
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="Object.keys(rankingData).length === 0" class="state-box">
+        <mdui-icon name="search_off" style="font-size: 48px;"></mdui-icon>
+        <p>暂无排行数据</p>
+    </div>
+
+    <!-- Rankings -->
+    <mdui-list v-else>
+        <mdui-collapse accordion>
+            <mdui-collapse-item v-for="[rankingName, ranking] of Object.entries(rankingData)" :key="rankingName">
+                <mdui-list-item slot="header" icon="leaderboard">
+                    <h3>{{ ranking.title || rankingName }} ({{ ranking.total }}) - {{ showDate(ranking.time) }}</h3>
+                </mdui-list-item>
+
+                <!-- My rank -->
+                <mdui-list-item v-if="ranking.me" class="me-row">
+                    🏅 {{ ranking.me.index }}. {{ ranking.me.nickname }} - {{ ranking.me.data }}
+                    <small v-if="ranking.me.info"> ({{ ranking.me.info }})</small>
+                </mdui-list-item>
+                <mdui-divider v-if="ranking.me" inset></mdui-divider>
+
+                <mdui-list-item v-for="user of ranking.users"
+                    :key="user.user_id + user.index">
+                    {{ user.index }}. {{ user.nickname }}
+                    <small v-if="user.info"> ({{ user.info }})</small>
+                    - {{ user.data }}
+                </mdui-list-item>
+                <mdui-divider inset></mdui-divider>
+            </mdui-collapse-item>
+        </mdui-collapse>
+    </mdui-list>
 </template>
+
+<style scoped lang="scss">
+.state-box {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--mdui-color-on-surface-variant);
+
+    p {
+        margin: 16px 0;
+    }
+}
+
+.me-row {
+    background: var(--mdui-color-primary-container);
+    font-weight: bold;
+
+    small {
+        font-weight: normal;
+        opacity: 0.7;
+    }
+}
+</style>

--- a/src/pages/RankingsView.vue
+++ b/src/pages/RankingsView.vue
@@ -35,7 +35,7 @@ function showDate(time: number) {
 				<mdui-list-item slot="header" icon="leaderboard">
 					<h3>{{ rankingName }} ({{ ranking.total }}) - {{ showDate(ranking.time) }}</h3>
 				</mdui-list-item>
-				<mdui-list-item v-for="user of ranking.users.sort((a, b) => a.index > b.index ? 1 : -1)"
+				<mdui-list-item v-for="user of ranking.users"
 								v-bind:key="user">
 					{{ user.index }}. {{ user.nickname }} ({{ user.info ?? user.user_id }}) - {{ user.data }}
 				</mdui-list-item>

--- a/src/pages/UserView.vue
+++ b/src/pages/UserView.vue
@@ -15,39 +15,55 @@ function logoutEvent() {
 	logout();
 	router.push('/login');
 }
+
+function levelExp(level: number): number {
+    return level ** 3 - (level - 1) ** 3;
+}
 </script>
 
 <template>
 	<div v-if="user">
 		<h2>用户</h2>
+
+		<!-- Avatar -->
+		<div class="avatar-section">
+			<mdui-avatar
+				v-if="user.avatar"
+				:src="'data:image/png;base64,' + user.avatar"
+				style="width: 80px; height: 80px;"
+			></mdui-avatar>
+			<mdui-avatar
+				v-else
+				style="width: 80px; height: 80px; font-size: 36px;"
+			>{{ user.nickname?.charAt(0) || '?' }}</mdui-avatar>
+		</div>
+
 		<table>
 			<tbody>
 			<tr>
 				<td>当前登录:</td>
-				<td>{{ user!!.nickname }} ({{ user!!.user_id }})</td>
+				<td>{{ user.nickname }} ({{ user.user_id }})</td>
 			</tr>
 			<tr>
 				<td>VimCoin:</td>
-				<td>{{ user!!.vimcoin }}</td>
+				<td>{{ user.vimcoin }}</td>
 			</tr>
 			<tr>
 				<td>等级:</td>
-				<td>{{ user!!.level }} ({{ user!!.experience }} /
-					{{ user!!.level ** 3 - (user!!.level - 1) ** 3 }})
-				</td>
+				<td>{{ user.level }} ({{ user.experience }} / {{ levelExp(user.level) }})</td>
 			</tr>
 			<tr>
 				<td>好感度</td>
-				<td>{{ user!!.favorability }}</td>
-			</tr>
-			<tr v-if="user?.register_time">
-				<td>血量</td>
-				<td>{{ user!!.health }} / 100</td>
+				<td>{{ user.favorability }}</td>
 			</tr>
 			<tr>
-					<td>注册时间:</td>
-					<td>{{ (new Date(user!!.register_time * 1000)).toString() }}</td>
-				</tr>
+				<td>血量</td>
+				<td>{{ user.health }} / 100</td>
+			</tr>
+			<tr v-if="user.register_time">
+				<td>注册时间:</td>
+				<td>{{ new Date(user.register_time * 1000).toLocaleString() }}</td>
+			</tr>
 			</tbody>
 		</table>
 		<p></p>
@@ -57,10 +73,17 @@ function logoutEvent() {
 		&nbsp;
 		<mdui-button icon="logout" end-icon="arrow_forward" @click="logoutEvent">退出登录</mdui-button>
 	</div>
-	<h1 v-else>加载中</h1>
+	<div v-else class="state-box">
+		<mdui-linear-progress indeterminate></mdui-linear-progress>
+		<p>加载中...</p>
+	</div>
 </template>
 
 <style scoped lang="scss">
+.avatar-section {
+    margin-bottom: 16px;
+}
+
 table {
 	width: 65%;
 	border-collapse: collapse;
@@ -82,5 +105,10 @@ caption {
 	caption-side: top;
 	font-size: 1.5em;
 	padding: 10px;
+}
+
+.state-box {
+    text-align: center;
+    padding: 40px 20px;
 }
 </style>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,100 @@
+import { getCookie, setCookie } from "./cookie";
+import { API_URL, BASE_URL } from "./utils";
+
+// ── Session ──
+
+export function getSessionIDOrNull(): string | null {
+    return getCookie("sessionID") ?? null;
+}
+
+export function getSessionID(): string {
+    return getSessionIDOrNull()!!;
+}
+
+export function logout(): void {
+    setCookie("sessionID", undefined);
+}
+
+// ── API Client ──
+
+type HttpMethod = "GET" | "POST" | "DELETE" | "PUT" | "PATCH";
+
+export interface RequestOptions {
+    method?: HttpMethod;
+    body?: unknown;
+    auth?: boolean;
+}
+
+async function buildHeaders(auth: boolean): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    };
+    if (auth) {
+        const sessionId = getSessionIDOrNull();
+        if (sessionId) {
+            headers["Authorization"] = `Bearer ${sessionId}`;
+        }
+    }
+    return headers;
+}
+
+/**
+ * API 请求（路径相对于 API_URL）
+ */
+export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const { method = "GET", body, auth = true } = options;
+    const headers = await buildHeaders(auth);
+    const response = await fetch(`${API_URL}${path}`, {
+        method,
+        headers,
+        body: body != null ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+        throw new ApiError(response.status, response.statusText);
+    }
+    return response.json();
+}
+
+/**
+ * API 请求（使用完整 BASE_URL + uri，用于服务端返回的绝对路径）
+ */
+export async function apiRequestFull<T>(uri: string, options: RequestOptions = {}): Promise<T> {
+    const { method = "GET", body, auth = true } = options;
+    const headers = await buildHeaders(auth);
+    const response = await fetch(`${BASE_URL}${uri}`, {
+        method,
+        headers,
+        body: body != null ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+        throw new ApiError(response.status, response.statusText);
+    }
+    return response.json();
+}
+
+/**
+ * 获取请求状态（不解析 body）
+ */
+export async function apiCheck(path: string): Promise<boolean> {
+    try {
+        const headers = await buildHeaders(true);
+        const response = await fetch(`${API_URL}${path}`, {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+                ...headers,
+            },
+        });
+        return response.ok;
+    } catch {
+        return false;
+    }
+}
+
+export class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+        super(`API Error ${status}: ${message}`);
+        this.status = status;
+    }
+}

--- a/src/utils/prefix.ts
+++ b/src/utils/prefix.ts
@@ -1,11 +1,6 @@
-import { API_URL } from "@/utils/utils";
+import { apiRequest } from "./api";
 
 export async function getPrefix(): Promise<string> {
-    const response = await fetch(API_URL + "/prefix", {
-        headers: {
-            "Content-Type": "application/json"
-        }
-    });
-    const data = await response.json();
-    return data.prefix as string;
+    const data = await apiRequest<{ prefix: string }>("/prefix", { auth: false });
+    return data.prefix;
 }

--- a/src/utils/ranking.ts
+++ b/src/utils/ranking.ts
@@ -13,7 +13,8 @@ export interface Rankings {
 export interface Ranking {
     time: number,
     total: number,
-    me: null | string,
+    title: string,  // 后端返回的排行标题
+    me: null | RankingUser,  // 是完整用户对象，不是字符串
     users: RankingUser[]
 }
 
@@ -22,11 +23,16 @@ export interface RankingUser {
     nickname: string,
     data: number,
     index: number,
-    info: null | string
+    info: null | string,
+    display?: string  // 后端可选返回
 }
 
 export async function getRankings() {
-    const fetcher = await fetch(API_URL + "/rankings", { method: "GET" });
+    const headers: Record<string, any> = {
+        "Content-Type": "application/json"
+    };
+    if (getSessionIDOrNull()) headers["Authorization"] = `Bearer ${ getSessionID() }`;
+    const fetcher = await fetch(API_URL + "/rankings", { method: "GET", headers });
     return (await fetcher.json()) as Rankings;
 }
 

--- a/src/utils/ranking.ts
+++ b/src/utils/ranking.ts
@@ -1,9 +1,8 @@
-import { getSessionID, getSessionIDOrNull } from "@/utils/user";
-import { API_URL, BASE_URL } from "@/utils/utils";
+import { apiRequest, apiRequestFull, getSessionIDOrNull } from "./api";
 
 export interface RankingInfo {
-    name: string,
-    uri: string,
+    name: string;
+    uri: string;
 }
 
 export interface Rankings {
@@ -11,41 +10,33 @@ export interface Rankings {
 }
 
 export interface Ranking {
-    time: number,
-    total: number,
-    title: string,  // 后端返回的排行标题
-    me: null | RankingUser,  // 是完整用户对象，不是字符串
-    users: RankingUser[]
+    time: number;
+    total: number;
+    title: string;
+    me: null | RankingUser;
+    users: RankingUser[];
 }
 
 export interface RankingUser {
-    user_id: string,
-    nickname: string,
-    data: number,
-    index: number,
-    info: null | string,
-    display?: string  // 后端可选返回
+    user_id: string;
+    nickname: string;
+    data: number;
+    index: number;
+    info: null | string;
+    display?: string;
 }
 
-export async function getRankings() {
-    const headers: Record<string, any> = {
-        "Content-Type": "application/json"
-    };
-    if (getSessionIDOrNull()) headers["Authorization"] = `Bearer ${ getSessionID() }`;
-    const fetcher = await fetch(API_URL + "/rankings", { method: "GET", headers });
-    return (await fetcher.json()) as Rankings;
+export async function getRankings(): Promise<Rankings> {
+    return apiRequest<Rankings>("/rankings");
 }
 
-export async function getRankingByURI(uri: string) {
-    const headers: Record<string, any> = {
-        "Content-Type": "application/json"
-    };
-    if (getSessionIDOrNull()) headers["Authorization"] = `Bearer ${ getSessionID() }`;
-    const fetcher = await fetch(BASE_URL + uri, { method: "GET", headers });
-    return (await fetcher.json()) as Ranking;
+export async function getRankingByURI(uri: string): Promise<Ranking> {
+    return apiRequestFull<Ranking>(uri);
 }
 
-export async function getRankingByName(rankingName: string) {
-    const rankingInfo = (await getRankings())[rankingName];
-    return await getRankingByURI(rankingInfo.uri);
+export async function getRankingByName(rankingName: string): Promise<Ranking> {
+    const rankings = await getRankings();
+    const info = rankings[rankingName];
+    if (!info) throw new Error(`Ranking "${rankingName}" not found`);
+    return getRankingByURI(info.uri);
 }

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,98 +1,65 @@
-import { getCookie, setCookie } from "@/utils/cookie";
-import { API_URL } from "@/utils/utils";
+import { apiRequest, apiCheck, logout as apiLogout, getSessionIDOrNull, getSessionID } from "./api";
 
-export function getSessionIDOrNull(): string | null {
-    return getCookie("sessionID") ?? null;
-}
-
-export function getSessionID(): string {
-    return getSessionIDOrNull()!!;
-}
+// Re-export session helpers for backward compatibility
+export { getSessionIDOrNull, getSessionID };
 
 export function logout(): void {
-    setCookie("sessionID", undefined);
+    apiLogout();
 }
 
 export async function isLoggedIn(): Promise<boolean> {
-    const response = await fetch(API_URL + "/users/me", {
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + getSessionID()
-        }
-    });
-    return response.ok;
+    return apiCheck("/users/me/permissions");
 }
 
 export async function requestBindMainAccount(mainUserID: string): Promise<string | undefined> {
-    const response = await fetch(API_URL + `/users/${ mainUserID }/sub-account/bind`, {
+    const data = await apiRequest<{ activate_code: string }>(`/users/${mainUserID}/sub-account/bind`, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + getSessionID()
-        }
     });
-    return (await response.json()).activate_code;
+    return data.activate_code;
 }
 
 export interface LoginResult {
-    session_id: string,
-    activate_code: string,
-    effective_time: number
+    session_id: string;
+    activate_code: string;
+    effective_time: number;
 }
 
 export interface ResultWithMessage {
-    success: boolean,
-    message: string
+    success: boolean;
+    message: string;
 }
 
 export interface UserData {
-    user_id: string,
-    nickname: string,
-    experience: number,
-    level: number,
-    vimcoin: number,
-    favorability: number,
-    health: number,
-    register_time: number | undefined,
-    avatar: string | undefined
+    user_id: string;
+    nickname: string;
+    experience: number;
+    total_experience: number;
+    level: number;
+    vimcoin: number;
+    favorability: number;
+    health: number;
+    register_time: number | undefined;
+    avatar: string | undefined;
 }
 
 export async function login(userID: string): Promise<LoginResult> {
-    const response = await fetch(API_URL + "/login", {
+    const data = await apiRequest<LoginResult>("/login", {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-            user_id: userID
-        })
+        body: { user_id: userID },
+        auth: false,
     });
-    const data = await response.json();
+    const { setCookie } = await import("./cookie");
     setCookie("sessionID", data.session_id);
     return data;
 }
 
 export async function postChangeNickname(nickname: string): Promise<ResultWithMessage> {
-    const response = await fetch(API_URL + "/users/me", {
+    return apiRequest<ResultWithMessage>("/users/me", {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + getSessionID()
-        },
-        body: JSON.stringify({
-            nickname: nickname
-        })
+        body: { nickname },
     });
-    return await response.json();
 }
 
 export async function getCurrentUser(): Promise<UserData> {
-    const response = await fetch(API_URL + "/users/me", {
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + getSessionID()
-        }
-    });
-    return await response.json();
+    return apiRequest<UserData>("/users/me");
 }
-


### PR DESCRIPTION
## 修改内容

- 新增统一 API 客户端 (utils/api.ts)，封装 fetch，统一 headers/认证/错误
- 新增 Toast 通知组件，替代原生 alert()
- isLoggedIn 改用 /users/me/permissions 轻量端点
- 排行榜显示当前用户排名(me) + 加载/空/错误状态
- 用户页展示头像
- 登录页加返回按钮 + 超时提示
- 导航栏 computed 响应路由高亮
- 修复 Ranking/RankingUser/UserData 类型定义