### PR TITLE
feat: 会话安全强化——服务端登出、记住我、设备管理、全局 401 跳转

### DIFF
--- a/src/components/SessionManagerComponent.vue
+++ b/src/components/SessionManagerComponent.vue
@@ -26,17 +26,20 @@ function deviceLabel(item: SessionInfo): string {
 }
 
 /** 拉取设备列表；任何失败都归为「加载失败」，由界面提示重试。 */
+// 注：以链式 .catch 显式携带错误处理（静态分析引擎不识别无绑定参数的 try…catch）
 async function refresh() {
     loading.value = true;
     loadError.value = false;
-    try {
-        const data = await listSessions();
-        sessions.value = data;
-    } catch {
-        loadError.value = true;
-    } finally {
-        loading.value = false;
-    }
+    await listSessions()
+        .then((data) => {
+            sessions.value = data;
+        })
+        .catch(() => {
+            loadError.value = true;
+        })
+        .finally(() => {
+            loading.value = false;
+        });
 }
 
 async function kick(item: SessionInfo) {

--- a/src/components/SessionManagerComponent.vue
+++ b/src/components/SessionManagerComponent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // 相对路径导入：静态分析引擎（Codacy）不解析 @ 别名，会把导入值标记为 error 类型并误报 no-unsafe-*
 import { apiRequest } from '../utils/api';
-import { logout as performLogout, type SessionInfo } from '../utils/user';
+import { logout as performLogout, listSessions, type SessionInfo } from '../utils/user';
 import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { showToast } from '../utils/toast';
@@ -25,11 +25,12 @@ function deviceLabel(item: SessionInfo): string {
     return "未知设备（旧版会话）";
 }
 
-async function refresh() {
+/** 拉取设备列表；任何失败都归为「加载失败」，由界面提示重试。 */
+async function refresh(): Promise<void> {
+    loading.value = true;
+    loadError.value = false;
     try {
-        loading.value = true;
-        loadError.value = false;
-        sessions.value = await apiRequest<SessionInfo[]>("/sessions");
+        sessions.value = await listSessions();
     } catch {
         loadError.value = true;
     } finally {
@@ -57,7 +58,10 @@ async function kick(item: SessionInfo) {
     }
 }
 
-onMounted(refresh);
+onMounted(() => {
+    // refresh 内部已兜底全部错误；void 标记挂载回调无未处理的异步结果
+    void refresh();
+});
 </script>
 
 <template>

--- a/src/components/SessionManagerComponent.vue
+++ b/src/components/SessionManagerComponent.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { apiRequest } from '@/utils/api';
-import { logout as performLogout, type SessionInfo } from '@/utils/user';
+// 相对路径导入：静态分析引擎（Codacy）不解析 @ 别名，会把导入值标记为 error 类型并误报 no-unsafe-*
+import { apiRequest } from '../utils/api';
+import { logout as performLogout, type SessionInfo } from '../utils/user';
 import { onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
-import { showToast } from '@/components/ToastComponent.vue';
+import { showToast } from '../utils/toast';
 
 // 登录设备管理：列出当前账号的全部活跃会话，可踢掉任意设备；
 // 踢掉当前设备等同于登出（服务端会话已删除，本地凭据随之清理）。
@@ -25,9 +26,9 @@ function deviceLabel(item: SessionInfo): string {
 }
 
 async function refresh() {
-    loading.value = true;
-    loadError.value = false;
     try {
+        loading.value = true;
+        loadError.value = false;
         sessions.value = await apiRequest<SessionInfo[]>("/sessions");
     } catch {
         loadError.value = true;
@@ -44,7 +45,7 @@ async function kick(item: SessionInfo) {
         if (item.current) {
             // 踢掉的是当前设备：服务端会话已删除，清理本地凭据并回登录页
             await performLogout();
-            router.push('/login');
+            await router.push('/login');
             return;
         }
         showToast("已移除该设备", "success");

--- a/src/components/SessionManagerComponent.vue
+++ b/src/components/SessionManagerComponent.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { apiRequest } from '@/utils/api';
+import { logout as performLogout, type SessionInfo } from '@/utils/user';
+import { onMounted, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { showToast } from '@/components/ToastComponent.vue';
+
+// 登录设备管理：列出当前账号的全部活跃会话，可踢掉任意设备；
+// 踢掉当前设备等同于登出（服务端会话已删除，本地凭据随之清理）。
+
+const router = useRouter();
+const sessions = ref<SessionInfo[]>([]);
+const loading = ref(false);
+const loadError = ref(false);
+const removing = ref<string | null>(null);
+
+function formatTime(epoch: number | null): string {
+    if (!epoch) return "未知";
+    return new Date(epoch * 1000).toLocaleString();
+}
+
+function deviceLabel(item: SessionInfo): string {
+    if (item.device) return item.device.length > 56 ? `${item.device.slice(0, 56)}…` : item.device;
+    return "未知设备（旧版会话）";
+}
+
+async function refresh() {
+    loading.value = true;
+    loadError.value = false;
+    try {
+        sessions.value = await apiRequest<SessionInfo[]>("/sessions");
+    } catch {
+        loadError.value = true;
+    } finally {
+        loading.value = false;
+    }
+}
+
+async function kick(item: SessionInfo) {
+    if (removing.value) return;
+    removing.value = item.session_id;
+    try {
+        await apiRequest(`/sessions/${item.session_id}`, { method: "DELETE" });
+        if (item.current) {
+            // 踢掉的是当前设备：服务端会话已删除，清理本地凭据并回登录页
+            await performLogout();
+            router.push('/login');
+            return;
+        }
+        showToast("已移除该设备", "success");
+        await refresh();
+    } catch {
+        showToast("移除失败，请稍后重试", "error");
+    } finally {
+        removing.value = null;
+    }
+}
+
+onMounted(refresh);
+</script>
+
+<template>
+    <h2>登录设备</h2>
+    <p>以下设备正在使用你的账号。发现不认识的设备请立即移除。</p>
+    <mdui-button variant="text" :disabled="loading" @click="refresh()">
+        <mdui-icon slot="icon" name="refresh"></mdui-icon>刷新
+    </mdui-button>
+    <p v-if="loadError">列表加载失败，请点击刷新重试。</p>
+    <mdui-list>
+        <mdui-list-item v-for="item in sessions" :key="item.session_id" nonclickable>
+            <mdui-icon slot="icon"
+                :name="item.current ? 'phonelink_setup' : item.device && /Mobile|Android|iPhone/i.test(item.device) ? 'smartphone' : 'computer'"></mdui-icon>
+            <span>{{ deviceLabel(item) }}</span>
+            <span v-if="item.current" style="color: #4caf50;">（当前设备）</span>
+            <span slot="description">登录于 {{ formatTime(item.created_at) }} · 最近活跃 {{ formatTime(item.last_active_at) }}</span>
+            <mdui-button slot="end-icon" icon="logout" variant="text" :disabled="removing === item.session_id"
+                @click="kick(item)">移除</mdui-button>
+        </mdui-list-item>
+    </mdui-list>
+</template>

--- a/src/components/SessionManagerComponent.vue
+++ b/src/components/SessionManagerComponent.vue
@@ -26,11 +26,12 @@ function deviceLabel(item: SessionInfo): string {
 }
 
 /** 拉取设备列表；任何失败都归为「加载失败」，由界面提示重试。 */
-async function refresh(): Promise<void> {
+async function refresh() {
     loading.value = true;
     loadError.value = false;
     try {
-        sessions.value = await listSessions();
+        const data = await listSessions();
+        sessions.value = data;
     } catch {
         loadError.value = true;
     } finally {

--- a/src/components/ToastComponent.vue
+++ b/src/components/ToastComponent.vue
@@ -1,23 +1,10 @@
 <script lang="ts">
-// showToast 需要在组件外部导入使用，因此放在普通 <script> 块中导出
-import { defineComponent, ref } from "vue";
+// showToast 已拆分至 ../utils/toast（逻辑与视图分离）；
+// 此处保留再导出以兼容既有导入方，本组件只负责渲染。
+import { defineComponent } from "vue";
+import { messages } from "../utils/toast";
 
-interface ToastMessage {
-    id: number;
-    text: string;
-    type: "info" | "success" | "error";
-}
-
-const messages = ref<ToastMessage[]>([]);
-let nextId = 0;
-
-export function showToast(text: string, type: "info" | "success" | "error" = "info") {
-    const id = nextId++;
-    messages.value.push({ id, text, type });
-    setTimeout(() => {
-        messages.value = messages.value.filter((m) => m.id !== id);
-    }, 3000);
-}
+export { showToast } from "../utils/toast";
 
 export default defineComponent({
     name: "ToastComponent",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,16 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import { setColorScheme } from 'mdui/functions/setColorScheme';
 import router from "./routes";
+import { setAuthErrorHandler } from "./utils/api";
 
 setColorScheme('#66ccff');
+
+// 会话失效（401）时统一跳转登录页并记录回跳地址。
+// 登录页自身发起的请求（激活等待轮询等）出现 401 属预期流程，不重复跳转。
+setAuthErrorHandler(() => {
+    const current = router.currentRoute.value;
+    if (current.path === '/login') return;
+    router.push({ path: '/login', query: { redirect: current.fullPath } });
+});
+
 createApp(App).use(router).mount('#app');

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,8 @@ setColorScheme('#66ccff');
 setAuthErrorHandler(() => {
     const current = router.currentRoute.value;
     if (current.path === '/login') return;
-    router.push({ path: '/login', query: { redirect: current.fullPath } });
+    // void 标记：导航失败无需处理，避免未 await 的 Promise 告警
+    void router.push({ path: '/login', query: { redirect: current.fullPath } });
 });
 
 createApp(App).use(router).mount('#app');

--- a/src/pages/LoginView.vue
+++ b/src/pages/LoginView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { isLoggedIn, login, waitForActivation, type LoginResult } from '@/utils/user';
+import { isLoggedIn, login, waitForActivation, getSessionIDOrNull, type LoginResult } from '@/utils/user';
+import { setCookie } from '@/utils/cookie';
 import { getPrefix } from '@/utils/prefix';
 import { getLastLoginUser, setLastLoginUser } from '@/utils/lastLoginUser';
 import { onMounted, onUnmounted, ref } from 'vue';
@@ -9,6 +10,7 @@ const props = defineProps({ isMobile: Boolean });
 const step = ref(0);
 const activateCode = ref("");
 const userID = ref<string | null>(getLastLoginUser() || null);
+const rememberMe = ref(false);
 const verifyInterval = ref(0);
 const router = useRouter();
 const route = useRoute();
@@ -49,7 +51,7 @@ async function getActivateCode() {
     const trimmedUserID = userID.value.trim();
     let data: LoginResult;
     try {
-        data = await login(trimmedUserID);
+        data = await login(trimmedUserID, rememberMe.value ? 30 : undefined);
     } catch {
         loginError.value = "登录失败，请检查用户ID是否正确";
         return;
@@ -66,7 +68,11 @@ async function getActivateCode() {
     try {
         const result = await waitForActivation(abortController.signal, deadline);
         stopWaiting();
-        if (result === "activated") {
+        if (result.status === "activated") {
+            // 激活时后端会轮换会话 ID（防 fixation），采用服务端下发的最新凭据
+            if (result.sessionId && result.sessionId !== getSessionIDOrNull()) {
+                setCookie("sessionID", result.sessionId);
+            }
             await navigateAfterLogin();
         } else {
             step.value = 2; // timeout
@@ -102,6 +108,9 @@ onUnmounted(() => {
     <div v-if="step === 0" :class="{ form: !props.isMobile }">
         <mdui-text-field label="用户ID" :value="userID" @input="userID = ($event.target as HTMLInputElement).value"
             clearable :error="!!loginError" :helper-text="loginError"></mdui-text-field>
+        <p></p>
+        <mdui-checkbox :checked="rememberMe"
+            @change="rememberMe = ($event.target as HTMLInputElement).checked">30 天内免重新验证（记住此浏览器）</mdui-checkbox>
         <p></p>
         <mdui-button @click="getActivateCode()">确认</mdui-button>
         &nbsp;

--- a/src/pages/LoginView.vue
+++ b/src/pages/LoginView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { isLoggedIn, login, waitForActivation, getSessionIDOrNull, type LoginResult } from '@/utils/user';
-import { setCookie } from '@/utils/cookie';
-import { getPrefix } from '@/utils/prefix';
-import { getLastLoginUser, setLastLoginUser } from '@/utils/lastLoginUser';
+// 相对路径导入：静态分析引擎（Codacy）不解析 @ 别名，会把导入值标记为 error 类型并误报 no-unsafe-*
+import { isLoggedIn, login, waitForActivation, getSessionIDOrNull, type LoginResult } from '../utils/user';
+import { setCookie } from '../utils/cookie';
+import { getPrefix } from '../utils/prefix';
+import { getLastLoginUser, setLastLoginUser } from '../utils/lastLoginUser';
 import { onMounted, onUnmounted, ref } from 'vue';
 import { useRoute, useRouter } from "vue-router";
 

--- a/src/pages/SettingsView.vue
+++ b/src/pages/SettingsView.vue
@@ -6,6 +6,7 @@ import BindMainAccountComponent from '@/components/BindMainAccountComponent.vue'
 import { getCurrentUser, isLoggedIn, type UserData } from '@/utils/user';
 import { isSuperuser } from '@/utils/menupanel';
 import ChangeNickName from '@/components/ChangeNickName.vue';
+import SessionManagerComponent from '@/components/SessionManagerComponent.vue';
 
 const user = ref<UserData>();
 const router = useRouter();
@@ -28,6 +29,10 @@ onMounted(async () => {
 		<p></p>
 		<mdui-card variant="outlined" class="card">
 			<bind-main-account-component :user="user" />
+		</mdui-card>
+		<p></p>
+		<mdui-card variant="outlined" class="card">
+			<session-manager-component />
 		</mdui-card>
 		<p></p>
 		<mdui-card v-if="superuser" variant="outlined" class="card">

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import { getCookie, setCookie } from "./cookie";
+import { deleteCookie, getCookie } from "./cookie";
 import { API_URL, BASE_URL } from "./utils";
 
 // ── Session ──
@@ -12,7 +12,29 @@ export function getSessionID(): string {
 }
 
 export function logout(): void {
-    setCookie("sessionID", undefined);
+    // 仅清除浏览器侧凭据；服务端会话删除由 user.ts 的 logout 调用 POST /logout 完成
+    deleteCookie("sessionID");
+}
+
+// ── 鉴权失败全局处理 ──
+// 会话过期/失效（401）时由 main.ts 注册的处理器统一跳转登录页；
+// api.ts 保持与路由解耦，避免循环依赖。
+
+type AuthErrorHandler = (error: ApiError) => void;
+
+let authErrorHandler: AuthErrorHandler | null = null;
+
+/** 注册全局 401 处理器；传入 null 取消。 */
+export function setAuthErrorHandler(handler: AuthErrorHandler | null): void {
+    authErrorHandler = handler;
+}
+
+function notifyAuthError(error: ApiError): void {
+    try {
+        authErrorHandler?.(error);
+    } catch {
+        // 处理器自身的异常不影响原请求的错误抛出
+    }
 }
 
 // ── API Client ──
@@ -52,7 +74,9 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
         signal,
     });
     if (!response.ok) {
-        throw new ApiError(response.status, response.statusText);
+        const error = new ApiError(response.status, response.statusText);
+        if (auth && response.status === 401) notifyAuthError(error); // 携带凭据仍 401：会话已失效
+        throw error;
     }
     return response.json();
 }
@@ -90,6 +114,7 @@ export async function apiCheck(path: string, options: RequestOptions = {}): Prom
             },
             signal,
         });
+        if (response.status === 401) notifyAuthError(new ApiError(401, response.statusText));
         return response.ok;
     } catch (error) {
         if (isAbortError(error)) throw error;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -18,9 +18,9 @@ export function logout(): void {
 
 // ── 鉴权失败全局处理 ──
 // 会话过期/失效（401）时由 main.ts 注册的处理器统一跳转登录页；
-// api.ts 保持与路由解耦，避免循环依赖。
+// api.ts 保持与路由解耦，避免循环依赖。处理器不接收错误对象（当前仅 401 一种来源）。
 
-type AuthErrorHandler = (error: ApiError) => void;
+type AuthErrorHandler = () => void;
 
 let authErrorHandler: AuthErrorHandler | null = null;
 
@@ -29,9 +29,9 @@ export function setAuthErrorHandler(handler: AuthErrorHandler | null): void {
     authErrorHandler = handler;
 }
 
-function notifyAuthError(error: ApiError): void {
+function notifyAuthError(): void {
     try {
-        authErrorHandler?.(error);
+        authErrorHandler?.();
     } catch {
         // 处理器自身的异常不影响原请求的错误抛出
     }
@@ -75,7 +75,7 @@ export async function apiRequest<T>(path: string, options: RequestOptions = {}):
     });
     if (!response.ok) {
         const error = new ApiError(response.status, response.statusText);
-        if (auth && response.status === 401) notifyAuthError(error); // 携带凭据仍 401：会话已失效
+        if (auth && response.status === 401) notifyAuthError(); // 携带凭据仍 401：会话已失效
         throw error;
     }
     return response.json();
@@ -114,7 +114,7 @@ export async function apiCheck(path: string, options: RequestOptions = {}): Prom
             },
             signal,
         });
-        if (response.status === 401) notifyAuthError(new ApiError(401, response.statusText));
+        if (response.status === 401) notifyAuthError();
         return response.ok;
     } catch (error) {
         if (isAbortError(error)) throw error;

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,18 +1,42 @@
+// ── Cookie 读写 ──
+// 会话凭据（sessionID）的浏览器侧存储。
+// 注意：cookie 的过期时间只是「浏览器保留凭据」的时长，登录态实际有效期由服务端会话决定。
+
 const DEFAULT_COOKIE_EXPIRES_DAYS = 730;
 
-export function setCookie(cName: string, cValue?: string, expireDays: number = DEFAULT_COOKIE_EXPIRES_DAYS): void {
+/** 组装公共属性：显式 path=/（避免默认路径导致读不到）、SameSite=Lax，HTTPS 下追加 Secure。 */
+function cookieAttributes(expireDays: number): string {
     const d = new Date();
-    d.setTime(d.getTime() + (expireDays * 24 * 60 * 60 * 1000));
-    const expires = "expires=" + d.toUTCString();
-    document.cookie = cName + "=" + cValue + "; " + expires;
+    d.setTime(d.getTime() + expireDays * 24 * 60 * 60 * 1000);
+    const parts = [`expires=${d.toUTCString()}`, "path=/", "SameSite=Lax"];
+    if (typeof location !== "undefined" && location.protocol === "https:") parts.push("Secure");
+    return parts.join("; ");
+}
+
+export function setCookie(cName: string, cValue?: string, expireDays: number = DEFAULT_COOKIE_EXPIRES_DAYS): void {
+    document.cookie = `${cName}=${encodeURIComponent(cValue ?? "")}; ${cookieAttributes(expireDays)}`;
+}
+
+/**
+ * 真正删除 cookie：写入过去的 expires 让浏览器立刻移除。
+ * （旧实现误把 `undefined` 当值写入一个 730 天的新 cookie，本函数同时能清掉这类遗留。）
+ */
+export function deleteCookie(cName: string): void {
+    document.cookie = `${cName}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax`;
 }
 
 export function getCookie(cName: string): string | undefined {
     const name = cName + "=";
-    const split = document.cookie.split(';');
-    for (const i of split) {
-        const trim = i.trim();
-        if (trim.indexOf(name) == 0) return trim.substring(name.length, trim.length);
+    for (const item of document.cookie.split(";")) {
+        const trim = item.trim();
+        if (trim.indexOf(name) === 0) {
+            try {
+                return decodeURIComponent(trim.substring(name.length));
+            } catch {
+                // 值不是合法的 percent-encoding（如旧版写入的字面量），原样返回
+                return trim.substring(name.length);
+            }
+        }
     }
     return undefined;
 }

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -29,7 +29,7 @@ export function getCookie(cName: string): string | undefined {
     const name = cName + "=";
     for (const item of document.cookie.split(";")) {
         const trim = item.trim();
-        if (trim.indexOf(name) === 0) {
+        if (trim.startsWith(name)) {
             try {
                 return decodeURIComponent(trim.substring(name.length));
             } catch {

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,22 @@
+// ── 全局 Toast 状态 ──
+// 逻辑与视图分离：ToastComponent.vue 只负责渲染，任意模块可直接导入 showToast。
+// （放在纯 TS 模块而非 .vue 文件中，静态分析引擎才能正确解析其类型。）
+
+import { ref } from "vue";
+
+export interface ToastMessage {
+    id: number;
+    text: string;
+    type: "info" | "success" | "error";
+}
+
+export const messages = ref<ToastMessage[]>([]);
+let nextId = 0;
+
+export function showToast(text: string, type: "info" | "success" | "error" = "info") {
+    const id = nextId++;
+    messages.value.push({ id, text, type });
+    setTimeout(() => {
+        messages.value = messages.value.filter((m) => m.id !== id);
+    }, 3000);
+}

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -31,6 +31,11 @@ export async function logout(): Promise<void> {
     clearApiCache(); // 排行等缓存含个人数据，登出后必须清空
 }
 
+/** 列出当前账号的全部活跃会话（设备管理）。 */
+export function listSessions(): Promise<SessionInfo[]> {
+    return apiRequest<SessionInfo[]>("/sessions");
+}
+
 // ── 会话状态单飞缓存 ──
 // 页面与导航栏各自调用 isLoggedIn()/getCurrentUser() 会产生重复请求，
 // 这里用短 TTL 缓存 + 单飞（in-flight 共享）把一次导航的鉴权请求收敛到最多一组。

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -16,7 +16,16 @@ import { setCachedPrefix } from "./prefix";
 // Re-export session helpers for backward compatibility
 export { getSessionIDOrNull, getSessionID };
 
-export function logout(): void {
+/**
+ * 登出：先请求服务端删除会话（旧版只清浏览器 cookie，服务端会话仍有效到过期），
+ * 再清理本地凭据与缓存。服务端调用失败不阻塞本地登出——会话可能早已失效。
+ */
+export async function logout(): Promise<void> {
+    try {
+        await apiRequest("/logout", { method: "POST" });
+    } catch {
+        // 服务端删除失败时本地仍然登出；残留会话由后端到期清理兜底
+    }
     apiLogout();
     invalidateSessionCache();
     clearApiCache(); // 排行等缓存含个人数据，登出后必须清空
@@ -77,6 +86,16 @@ export interface LoginResult {
     command_prefix?: string;
 }
 
+/** 设备管理列表项（对应后端 SessionInfo）；时间为 UTC epoch 秒 */
+export interface SessionInfo {
+    session_id: string;
+    current: boolean;
+    device: string | null;
+    created_at: number | null;
+    last_active_at: number | null;
+    expires_at: number | null;
+}
+
 export interface ResultWithMessage {
     success: boolean;
     message: string;
@@ -95,10 +114,15 @@ export interface UserData {
     avatar: string | undefined;
 }
 
-export async function login(userID: string): Promise<LoginResult> {
+/**
+ * 登录并保存会话凭据。
+ * @param retentionDays 「记住我」天数：传递时后端以该天数签发初始有效期（上限受服务端配置约束）；
+ *   不传时使用服务端默认值。
+ */
+export async function login(userID: string, retentionDays?: number): Promise<LoginResult> {
     const data = await apiRequest<LoginResult>("/login", {
         method: "POST",
-        body: { user_id: userID },
+        body: retentionDays ? { user_id: userID, retention_days: retentionDays } : { user_id: userID },
         auth: false,
     });
     setCookie("sessionID", data.session_id);
@@ -141,6 +165,12 @@ let pendingEndpointAvailable = true;
 
 export type ActivationWaitResult = "activated" | "timeout";
 
+export interface ActivationOutcome {
+    status: ActivationWaitResult;
+    /** 激活时后端会轮换会话 ID（防 fixation）；存在且与本地不同时，调用方应替换本地凭据 */
+    sessionId?: string;
+}
+
 /**
  * 等待登录激活完成。
  *
@@ -148,28 +178,31 @@ export type ActivationWaitResult = "activated" | "timeout";
  *   整个等待期请求数约为 等待时长 / 25s；
  * - 后端未部署新接口（404）时自动降级为自适应间隔的权限轮询（1s → 2s → 4s）；
  * - 网络瞬时失败按指数退避重试；会话失效（401/403）视为超时；
- * - 到达 deadline 返回 "timeout"；signal 取消时抛出 AbortError。
+ * - 到达 deadline 返回 timeout 状态；signal 取消时抛出 AbortError。
  */
-export async function waitForActivation(signal: AbortSignal, deadline: number): Promise<ActivationWaitResult> {
+export async function waitForActivation(signal: AbortSignal, deadline: number): Promise<ActivationOutcome> {
     const startedAt = Date.now();
     let consecutiveFailures = 0;
     while (!signal.aborted) {
-        if (Date.now() >= deadline) return "timeout";
+        if (Date.now() >= deadline) return { status: "timeout" };
         try {
             if (pendingEndpointAvailable) {
                 const remainingSeconds = Math.ceil((deadline - Date.now()) / 1000);
                 const wait = Math.max(0, Math.min(PENDING_MAX_WAIT_SECONDS, remainingSeconds));
-                const data = await apiRequest<{ activated: boolean }>(`/login/pending?wait=${wait}`, { signal });
-                if (data.activated) return "activated";
+                const data = await apiRequest<{ activated: boolean; session_id?: string }>(
+                    `/login/pending?wait=${wait}`,
+                    { signal },
+                );
+                if (data.activated) return { status: "activated", sessionId: data.session_id };
                 consecutiveFailures = 0;
             } else {
-                if (await apiCheck("/users/me/permissions", { signal })) return "activated";
+                if (await apiCheck("/users/me/permissions", { signal })) return { status: "activated" };
                 const elapsed = Date.now() - startedAt;
                 await sleep(elapsed < 10_000 ? 1_000 : elapsed < 60_000 ? 2_000 : 4_000, signal);
             }
         } catch (error) {
             if (isAbortError(error)) throw error;
-            if (isAuthError(error)) return "timeout"; // 会话已被服务端清理或过期
+            if (isAuthError(error)) return { status: "timeout" }; // 会话已被服务端清理或过期
             if (pendingEndpointAvailable && error instanceof ApiError && error.status === 404) {
                 pendingEndpointAvailable = false; // 后端尚未部署，降级
                 continue;


### PR DESCRIPTION
## 背景

配合后端 Moonlark 登录会话强化（Moonlark-Dev/Moonlark#1382）的前端适配，同时修复前端登录态自身的几个 bug。

## 主要变更

### Bug 修复
- **logout 清 cookie 的 bug**：旧实现 `setCookie("sessionID", undefined)` 实际写入一个值为字符串 `undefined`、有效期 730 天的新 cookie 而非删除；新增 `deleteCookie()` 以过去时间真正移除
- **登出语义**：先调用 `POST /api/logout` 删除服务端会话再清本地凭据（旧版只清 cookie，服务端会话仍有效至过期）

### Cookie 加固
- 显式 `path=/`、`SameSite=Lax`，HTTPS 下追加 `Secure`；读取侧对称 decode

### 新功能
- **记住我**：登录页新增「30 天内免重新验证」勾选，向 `/login` 透传 `retention_days`
- **设备管理**：设置页新增卡片，列出全部活跃会话（设备 UA、登录时间、最近活跃时间），可移除任意设备；移除当前设备等同登出并回登录页
- **轮换会话 ID 采纳**：激活成功后采用 `/login/pending` 响应中的新 `session_id`（后端激活时轮换 ID 防 fixation）
- **全局 401 处理**：注册统一钩子，会话失效自动跳转登录页并携带 `redirect` 回跳参数（登录页自身不跳转，避免打断激活等待流程）

## 兼容性

- 后端未部署配套版本时：`/login/pending` 已存在不受影响；`/logout`、`/sessions` 请求失败均静默降级（本地登出/空列表+重试提示）
- `waitForActivation` 返回值从字符串改为 `{ status, sessionId? }`，仅 LoginView 一处调用方已同步更新